### PR TITLE
chore: make provider compatible with the latest Dependency Track version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 
 services:
   dtrack-apiserver:
-    image: dependencytrack/apiserver:4.11.5
+    image: dependencytrack/apiserver:4.13.2
     # environment:
     # The Dependency-Track container can be configured using any of the
     # available configuration properties defined in:

--- a/docs/resources/team_api_key.md
+++ b/docs/resources/team_api_key.md
@@ -19,6 +19,12 @@ API Key for a team
 
 - `team_id` (String) ID of the team
 
+### Optional
+
+- `comment` (String) The API key comment
+
 ### Read-Only
 
+- `id` (String) Generated ID of the API key, the public ID returned by the API
+- `legacy` (Boolean) Whether the key is legacy or not
 - `value` (String, Sensitive) Value of the API key

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819 // indirect
-	golang.org/x/mod v0.16.0 // indirect
+	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,6 @@ github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
-github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
-github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
@@ -328,8 +326,8 @@ golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819/go.mod h1:FXUEEKJgO7OQYeo8N0
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
-golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
-golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
+golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/provider/configproperty/config_property_resource_test.go
+++ b/internal/provider/configproperty/config_property_resource_test.go
@@ -225,11 +225,11 @@ func testAccCheckConfigPropertyHasExpectedValue(ctx context.Context, testDepende
 		if configProperty == nil {
 			return fmt.Errorf("failed to find config property [%s]/[%s] from Dependency-Track", groupName, name)
 		}
-		if configProperty.PropertyValue == nil {
+		if configProperty.Value == "" {
 			return fmt.Errorf("config property [%s]/[%s] has no value", groupName, name)
 		}
 
-		configPropertyValue := *configProperty.PropertyValue
+		configPropertyValue := configProperty.Value
 		if configPropertyValue != expectedValue {
 			return fmt.Errorf("config property [%s]/[%s] has value [%s] instead of the expected [%s]", groupName, name, configPropertyValue, expectedValue)
 		}
@@ -239,13 +239,13 @@ func testAccCheckConfigPropertyHasExpectedValue(ctx context.Context, testDepende
 }
 
 func findConfigProperty(ctx context.Context, testDependencyTrack *testutils.TestDependencyTrack, groupName, name string) (*dtrack.ConfigProperty, error) {
-	configProperties, err := testDependencyTrack.Client.Config.GetAllConfigProperties(ctx)
+	configProperties, err := testDependencyTrack.Client.Config.GetAll(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config properties from Dependency-Track: %w", err)
 	}
 
 	for _, configProperty := range configProperties {
-		if configProperty.GroupName == groupName && configProperty.PropertyName == name {
+		if configProperty.GroupName == groupName && configProperty.Name == name {
 			return &configProperty, nil
 		}
 	}
@@ -254,13 +254,13 @@ func findConfigProperty(ctx context.Context, testDependencyTrack *testutils.Test
 }
 
 func setConfigProperty(ctx context.Context, testDependencyTrack *testutils.TestDependencyTrack, groupName, name, value string) error {
-	setConfigPropertyRequest := dtrack.SetConfigPropertyRequest{
-		GroupName:     groupName,
-		PropertyName:  name,
-		PropertyValue: value,
+	setConfigPropertyRequest := dtrack.ConfigProperty{
+		GroupName: groupName,
+		Name:      name,
+		Value:     value,
 	}
 
-	_, err := testDependencyTrack.Client.Config.SetConfigProperty(ctx, setConfigPropertyRequest)
+	_, err := testDependencyTrack.Client.Config.Update(ctx, setConfigPropertyRequest)
 	if err != nil {
 		return fmt.Errorf("failed to set config property in Dependency-Track: %w", err)
 	}

--- a/internal/testutils/projecttestutils/project_test_utils.go
+++ b/internal/testutils/projecttestutils/project_test_utils.go
@@ -32,7 +32,7 @@ func TestAccCheckProjectExistsAndHasExpectedLazyData(ctx context.Context, testDe
 			return fmt.Errorf("project for resource %s does not exist in Dependency-Track", resourceName)
 		}
 
-		diff := cmp.Diff(project, &expectedProject, cmpopts.IgnoreFields(dtrack.Project{}, "UUID", "Properties", "Tags", "Metrics"))
+		diff := cmp.Diff(project, &expectedProject, cmpopts.IgnoreFields(dtrack.Project{}, "UUID", "Properties", "Tags", "Metrics", "IsLatest"))
 		if diff != "" {
 			return fmt.Errorf("project for resource %s is different than expected: %s", resourceName, diff)
 		}

--- a/internal/testutils/test_dependency_track.go
+++ b/internal/testutils/test_dependency_track.go
@@ -197,7 +197,7 @@ func newTestDependencyTrackFromInternalContainer(config *testDependencyTrackConf
 
 func startDependencyTrackContainer(ctx context.Context) (testcontainers.Container, error) {
 	containerRequest := testcontainers.ContainerRequest{
-		Image:        "dependencytrack/apiserver:4.11.5",
+		Image:        "dependencytrack/apiserver:4.13.2",
 		ExposedPorts: []string{"8080/tcp"},
 		WaitingFor:   wait.ForLog("Dependency-Track is ready").WithStartupTimeout(2 * time.Minute),
 	}
@@ -333,7 +333,8 @@ func createAllPowerfulApiKey(ctx context.Context, client *dtrack.Client) (apiKey
 
 	fmt.Printf("Granted all %d permissions to team %s\n", len(allPermissions.Items), teamName)
 
-	apiKey, err = client.Team.GenerateAPIKey(ctx, team.UUID)
+	apiKeyObject, err := client.Team.GenerateAPIKey(ctx, team.UUID)
+	apiKey = apiKeyObject.Key
 	if err != nil {
 		return "", fmt.Errorf("could not create Dependency-Track API key for test team: %w", err)
 	}


### PR DESCRIPTION
This MR makes the terraform provider compatible with the latest Dependency Track version

Things that are changed:
- Updated code to be compatible with the changes made to the dependency-track-client-go in https://github.com/futurice/dependency-track-client-go/pull/2
- Updated the Dependency Track version used in the API to 4.13.2
- Implemented the new API key handling
- Ignored new fields in the project resource tests
- Added the API key comment field to the team_api_key resource

> ❗**NOTE**❗: The tests will fail until the dependency-track-client-go version is updated in the `go.mod` file. I couldn't update it as the MR in the client-go mentioned above is not yet merged.